### PR TITLE
fix queue message disappearing issue

### DIFF
--- a/application/factory/consumer_factory.py
+++ b/application/factory/consumer_factory.py
@@ -10,7 +10,7 @@ from utils.exceptions import InternalServerErrorException
 logger = get_logger(__name__)
 
 
-def format_ethereum_event(event):
+def format_ethereum_event(event) -> list:
     new_format = []
     name = event.get(EthereumEventConsumerEntities.NAME.value, None)
     data = event.get(EthereumEventConsumerEntities.DATA.value, None)
@@ -20,7 +20,7 @@ def format_ethereum_event(event):
     return new_format
 
 
-def convert_consumer_event(event):
+def convert_consumer_event(event) -> list:
     new_format = []
     records = event.get(CardanoEventConsumer.RECORDS.value, [])
     try:
@@ -52,7 +52,7 @@ def consumer_required_format(blockchain_name, blockchain_event):
     }
 
 
-def convert_converter_bridge_event(event):
+def convert_converter_bridge_event(event) -> list:
     new_format = []
     records = event.get(ConverterBridgeEntities.RECORDS.value, [])
     try:

--- a/application/handler/consumer_handlers.py
+++ b/application/handler/consumer_handlers.py
@@ -20,6 +20,7 @@ logger = get_logger(__name__)
 def post_converter_ethereum_events_to_queue(event, context):
     logger.debug(f"Posting ethereum events to queue event={json.dumps(event)}")
     new_format = format_ethereum_event(event=event)
+    logger.info(f"Total events received={len(new_format)}")
     for event in new_format:
         ConsumerService.post_converter_ethereum_events_to_queue(event)
 
@@ -28,6 +29,7 @@ def post_converter_ethereum_events_to_queue(event, context):
 def converter_event_consumer(event, context):
     logger.debug(f"Confirm and trigger transaction process request event={json.dumps(event)}")
     new_format = convert_consumer_event(event=event)
+    logger.info(f"Total events received={len(new_format)}")
     for event in new_format:
         consumer_service.converter_event_consumer(payload=event)
 
@@ -36,5 +38,6 @@ def converter_event_consumer(event, context):
 def converter_bridge(event, context):
     logger.debug(f"Converter bridge request event={json.dumps(event)}")
     new_format = convert_converter_bridge_event(event=event)
+    logger.info(f"Total events received={len(new_format)}")
     for event in new_format:
         consumer_service.converter_bridge(payload=event)

--- a/application/service/consumer_service.py
+++ b/application/service/consumer_service.py
@@ -140,6 +140,7 @@ class ConsumerService:
                                                          tx_status=TransactionStatus.SUCCESS.value)
 
         conversion_id = conversion.get(ConversionEntities.ID.value)
+        logger.info(f"Conversion id= {conversion_id}")
         conversion_complete_detail = self.conversion_service.get_conversion_complete_detail(conversion_id=conversion_id)
 
         if not conversion_complete_detail:
@@ -353,9 +354,8 @@ class ConsumerService:
             print("Successfully processed the request")
         else:
             logger.info("Unable to match the request activity event")
-            raise InternalServerErrorException(error_code=ErrorCode.ACTIVITY_EVENT_NOT_MATCHING.value,
-                                               error_details=ErrorDetails[
-                                                   ErrorCode.ACTIVITY_EVENT_NOT_MATCHING.value].value)
+            raise BadRequestException(error_code=ErrorCode.ACTIVITY_EVENT_NOT_MATCHING.value,
+                                      error_details=ErrorDetails[ErrorCode.ACTIVITY_EVENT_NOT_MATCHING.value].value)
 
     def process_converter_bridge_request(self, conversion_complete_detail, payload):
         logger.info("Processing the conversion bridge request")

--- a/serverless.yml
+++ b/serverless.yml
@@ -74,6 +74,8 @@ custom:
       - X-Amz-Security-Token
       - X-Amz-User-Agent
       - x-requested-with
+  defaultQueueRetry: 5
+  defaultMessageRetentionPeriod: 14400
   documentation:
     models:
       - name: "ApiErrorMessage"
@@ -219,7 +221,7 @@ resources:
         QueueName: ${file(./config.${self:provider.stage}.json):ENVIRONMENT}-converter-event-consumer
         VisibilityTimeout: 60
         ReceiveMessageWaitTimeSeconds: 20
-        MessageRetentionPeriod: 7200
+        MessageRetentionPeriod: ${self:custom.defaultMessageRetentionPeriod}
         RedrivePolicy:
           deadLetterTargetArn: !GetAtt converterEventConsumerDLQQueue.Arn
           maxReceiveCount: 15
@@ -283,12 +285,12 @@ resources:
         FifoQueue: true
         ContentBasedDeduplication: true
         QueueName: ${file(./config.${self:provider.stage}.json):ENVIRONMENT}-converter-bridge1.fifo
-        VisibilityTimeout: 400
+        VisibilityTimeout: 320
         ReceiveMessageWaitTimeSeconds: 20
-        MessageRetentionPeriod: 7200
+        MessageRetentionPeriod: ${self:custom.defaultMessageRetentionPeriod}
         RedrivePolicy:
           deadLetterTargetArn: !GetAtt converterBridgeDLQQueue.Arn
-          maxReceiveCount: 10
+          maxReceiveCount: ${self:custom.defaultQueueRetry}
 
     converterBridgeQueue1Policy:
       Type: AWS::SQS::QueuePolicy
@@ -312,12 +314,12 @@ resources:
         FifoQueue: true
         ContentBasedDeduplication: true
         QueueName: ${file(./config.${self:provider.stage}.json):ENVIRONMENT}-converter-bridge2.fifo
-        VisibilityTimeout: 400
+        VisibilityTimeout: 320
         ReceiveMessageWaitTimeSeconds: 20
-        MessageRetentionPeriod: 7200
+        MessageRetentionPeriod: ${self:custom.defaultMessageRetentionPeriod}
         RedrivePolicy:
           deadLetterTargetArn: !GetAtt converterBridgeDLQQueue.Arn
-          maxReceiveCount: 10
+          maxReceiveCount: ${self:custom.defaultQueueRetry}
 
     converterBridgeQueue2Policy:
       Type: AWS::SQS::QueuePolicy
@@ -341,12 +343,12 @@ resources:
         FifoQueue: true
         ContentBasedDeduplication: true
         QueueName: ${file(./config.${self:provider.stage}.json):ENVIRONMENT}-converter-bridge3.fifo
-        VisibilityTimeout: 400
+        VisibilityTimeout: 320
         ReceiveMessageWaitTimeSeconds: 20
-        MessageRetentionPeriod: 7200
+        MessageRetentionPeriod: ${self:custom.defaultMessageRetentionPeriod}
         RedrivePolicy:
           deadLetterTargetArn: !GetAtt converterBridgeDLQQueue.Arn
-          maxReceiveCount: 10
+          maxReceiveCount: ${self:custom.defaultQueueRetry}
 
     converterBridgeQueue3Policy:
       Type: AWS::SQS::QueuePolicy
@@ -370,12 +372,12 @@ resources:
         FifoQueue: true
         ContentBasedDeduplication: true
         QueueName: ${file(./config.${self:provider.stage}.json):ENVIRONMENT}-converter-bridge4.fifo
-        VisibilityTimeout: 400
+        VisibilityTimeout: 320
         ReceiveMessageWaitTimeSeconds: 20
-        MessageRetentionPeriod: 7200
+        MessageRetentionPeriod: ${self:custom.defaultMessageRetentionPeriod}
         RedrivePolicy:
           deadLetterTargetArn: !GetAtt converterBridgeDLQQueue.Arn
-          maxReceiveCount: 10
+          maxReceiveCount: ${self:custom.defaultQueueRetry}
 
     converterBridgeQueue4Policy:
       Type: AWS::SQS::QueuePolicy
@@ -775,6 +777,7 @@ functions:
             Fn::GetAtt:
               - converterEventConsumerQueue
               - Arn
+          batchSize: 1
 
   converter_bridge1:
     handler: application/handler/consumer_handlers.converter_bridge

--- a/testcases/functional_testcases/test_consumer_handlers.py
+++ b/testcases/functional_testcases/test_consumer_handlers.py
@@ -329,14 +329,14 @@ class TestConsumer(unittest.TestCase):
                                                                      'tx_operation': 'TOKEN_BURNT'},
                                                                  'blockchain_network_id': 2}), {})
 
-        # Internal server error because this conversion id doesn't have transactions
-        self.assertRaises(InternalServerErrorException, converter_bridge,
-                          prepare_converter_bridge_event_format({'blockchain_name': 'Cardano',
-                                                                 'blockchain_event': {
-                                                                     'conversion_id': '7298bce110974411b260cac758b37ee0',
-                                                                     'tx_amount': '1E+8',
-                                                                     'tx_operation': 'TOKEN_BURNT'},
-                                                                 'blockchain_network_id': 2}), {})
+        # Bad Request error because input event won't match with generated event
+        response = converter_bridge(prepare_converter_bridge_event_format({'blockchain_name': 'Cardano',
+                                                                           'blockchain_event': {
+                                                                               'conversion_id': '7298bce110974411b260cac758b37ee0',
+                                                                               'tx_amount': '1E+8',
+                                                                               'tx_operation': 'TOKEN_BURNT'},
+                                                                           'blockchain_network_id': 2}), {})
+        self.assertEqual(response, None)
 
         conversion = conversion_repo.session.query(ConversionDBModel).filter(
             ConversionDBModel.id == "7298bce110974411b260cac758b37ee0").first()
@@ -360,14 +360,14 @@ class TestConsumer(unittest.TestCase):
                                 created_at="2022-01-12 04:10:54",
                                 updated_at="2022-01-12 04:10:54")])
 
-        # Internal server error because input event won't match with generated event
-        self.assertRaises(InternalServerErrorException, converter_bridge,
-                          prepare_converter_bridge_event_format({'blockchain_name': 'Cardano',
-                                                                 'blockchain_event': {
-                                                                     'conversion_id': '7298bce110974411b260cac758b37ee0',
-                                                                     'tx_amount': '1E+8',
-                                                                     'tx_operation': 'TOKEN_BURNT'},
-                                                                 'blockchain_network_id': 2}), {})
+        # Bad Request error because input event won't match with generated event
+        response = converter_bridge(prepare_converter_bridge_event_format({'blockchain_name': 'Cardano',
+                                                                           'blockchain_event': {
+                                                                               'conversion_id': '7298bce110974411b260cac758b37ee0',
+                                                                               'tx_amount': '1E+8',
+                                                                               'tx_operation': 'TOKEN_BURNT'},
+                                                                           'blockchain_network_id': 2}), {})
+        self.assertEqual(response, None)
 
         # valid request
         mock_get_block.return_value = {"confirmations": 0}


### PR DESCRIPTION
- Fixed the message disappearing issue (Messages are processed in batch  for 4 conversions which we reprocessed manually, though we throw as an exception, it treats as a success, so now processing one at a time per parallel processing )
- Increased the message retention to 4 hours
- Fixed that `event did not match`  error to bad request
-  Reduced the retry of SQS from 10 to 5
- Decreased the visibility from 400 t0 320 because lambda only it has 300 seconds timeout and 20 seconds for buffer