### PR TITLE
Removing float conversion

### DIFF
--- a/application/service/cardano_service.py
+++ b/application/service/cardano_service.py
@@ -55,7 +55,7 @@ class CardanoService:
                                                    ErrorCode.LAMBDA_ARN_BURN_NOT_FOUND.value].value)
         try:
             payload = CardanoService.generate_payload_format(conversion_id=conversion_id, address=address,
-                                                             tx_amount=str(Decimal(float(tx_amount))),
+                                                             tx_amount=str(Decimal(tx_amount)),
                                                              tx_details=tx_details)
             payload[CardanoAPIEntities.DEPOSIT_ADDRESS_DETAILS.value] = deposit_address_details
             logger.info(f"Payload for burning ={json.dumps(payload)}")
@@ -91,9 +91,9 @@ class CardanoService:
         try:
             payload = CardanoService.generate_payload_format(conversion_id=conversion_id,
                                                              address=address,
-                                                             tx_amount=str(Decimal(float(tx_amount))),
+                                                             tx_amount=str(Decimal(tx_amount)),
                                                              tx_details=tx_details,
-                                                             fee=str(Decimal(float(fee))),
+                                                             fee=str(Decimal(fee)),
                                                              decimals_difference=decimals_difference)
             payload[CardanoAPIEntities.SOURCE_ADDRESS.value] = source_address
             logger.info(f"Payload for minting = {json.dumps(payload)}")

--- a/application/service/consumer_service.py
+++ b/application/service/consumer_service.py
@@ -233,7 +233,7 @@ class ConsumerService:
                 raise InternalServerErrorException(error_code=ErrorCode.MISMATCH_AMOUNT.value,
                                                    error_details=ErrorDetails[ErrorCode.MISMATCH_AMOUNT.value].value)
 
-        if event_type == EthereumEventType.TOKEN_BURNT.value and Decimal(float(deposit_amount)) != Decimal(tx_amount):
+        if event_type == EthereumEventType.TOKEN_BURNT.value and Decimal(deposit_amount) != Decimal(tx_amount):
             token_pair_row_id = wallet_pair.get(WalletPairEntities.TOKEN_PAIR_ID.value)
             token_pair = self.token_service.get_token_pair_internal(token_pair_id=None,
                                                                     token_pair_row_id=token_pair_row_id)
@@ -318,7 +318,7 @@ class ConsumerService:
                 raise BadRequestException(error_code=ErrorCode.INVALID_ASSET_TRANSFERRED.value,
                                           error_details=ErrorDetails[ErrorCode.INVALID_ASSET_TRANSFERRED.value].value)
 
-            tx_amount = Decimal(float(tx_amount))
+            tx_amount = Decimal(tx_amount)
             if token_pair.get(TokenPairEntities.CONVERSION_FEE.value):
                 if from_token_decimals != to_token_decimals:
                     # Conversion fee temporary not allowed for token pairs with different decimals amount

--- a/application/service/conversion_service.py
+++ b/application/service/conversion_service.py
@@ -384,8 +384,8 @@ class ConversionService:
             conversion = self.get_latest_user_pending_conversion_request(wallet_pair_id=wallet_pair_id)
 
         if conversion and (created_by == CreatedBy.DAPP.value or
-                           Decimal(float(conversion.get(ConversionEntities.DEPOSIT_AMOUNT.value))) != deposit_amount
-                           or Decimal(float(conversion.get(ConversionEntities.FEE_AMOUNT.value))) != fee_amount):
+                           Decimal(conversion.get(ConversionEntities.DEPOSIT_AMOUNT.value)) != deposit_amount
+                           or Decimal(conversion.get(ConversionEntities.FEE_AMOUNT.value)) != fee_amount):
             self.update_conversion(conversion_id=conversion[ConversionEntities.ID.value],
                                    status=ConversionStatus.EXPIRED.value)
             conversion = None
@@ -563,7 +563,7 @@ class ConversionService:
         claim_amount = conversion.get(ConversionEntities.CLAIM_AMOUNT.value)
         fee_amount = conversion.get(ConversionEntities.FEE_AMOUNT.value)
         # We should return total amount of tokens because contract on the Ethereum side calculate fees by itself
-        claim_amount = str(Decimal(float(claim_amount)) + Decimal(float(fee_amount)))
+        claim_amount = str(Decimal(claim_amount) + Decimal(fee_amount))
         user_address = conversion_detail.get(ConversionDetailEntities.WALLET_PAIR.value) \
                                         .get(WalletPairEntities.TO_ADDRESS.value)
         contract_address = self.get_token_contract_address_for_conversion_id(
@@ -573,7 +573,7 @@ class ConversionService:
         # Generate claim signature
         claim_signature = get_signature(signature_type=SignatureTypeEntities.CONVERSION_IN.value,
                                         user_address=user_address, conversion_id=conversion_id,
-                                        amount=Decimal(float(claim_amount)),
+                                        amount=Decimal(claim_amount),
                                         contract_address=contract_address, chain_id=chain_id)
         # Update the signature and status
         self.update_conversion(conversion_id=conversion_id, claim_signature=claim_signature)

--- a/utils/blockchain.py
+++ b/utils/blockchain.py
@@ -331,7 +331,7 @@ def get_conversion_next_event(conversion_complete_detail, expected_events_flow):
             break
         conversion_side = ConversionOn.TO.value
 
-    tx_amount = Decimal(float(conversion.get(ConversionEntities.DEPOSIT_AMOUNT.value)))
+    tx_amount = Decimal(conversion.get(ConversionEntities.DEPOSIT_AMOUNT.value))
     if conversion_side == ConversionOn.FROM.value:
         blockchain = conversion_complete_detail.get(ConversionDetailEntities.FROM_TOKEN.value, {}) \
                                                .get(TokenEntities.BLOCKCHAIN.value, {})
@@ -496,7 +496,7 @@ def validate_conversion_claim_request_signature(conversion_detail, amount, from_
 
 
 def convert_str_to_decimal(value):
-    return Decimal(float(value))
+    return Decimal(value)
 
 
 def convert_int_to_decimal(value):
@@ -506,8 +506,8 @@ def convert_int_to_decimal(value):
 def validate_conversion_request_amount(amount: str, min_value: str, max_value: str) -> None:
     logger.info(f"Validating the conversion request amount limits where amount={amount}, min_value={min_value}, "
                 f"max_value={max_value}")
-    min_value = Decimal(float(min_value))
-    max_value = Decimal(float(max_value))
+    min_value = Decimal(min_value)
+    max_value = Decimal(max_value)
     amount = convert_str_to_decimal(value=amount)
 
     if (amount - int(amount)) > Decimal(0):


### PR DESCRIPTION
This PR removes redundant conversions that may return incorrect values for large numbers.

For example:
![x](https://github.com/user-attachments/assets/2913404b-5bc0-42a5-b029-84a79715b7a3)
